### PR TITLE
Adding in package.json prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "coverage": "nyc npm run test",
     "watch": "npm run build -- --watch",
     "watch:test": "npm run test -- --watch",
-    "prepublishOnly": "npm run clean && npm run build"
+    "prepublishOnly": "npm run clean && npm run build",
+    "prepare": "npm run build"
   },
   "dependencies": {
     "@types/debug": "^0.0.30",


### PR DESCRIPTION
This addresses the following `import` errors. 

```
src/models/group.ts:5:33 - error TS2307: Cannot find module 'keycloak-admin/lib/defs/groupRepresentation'.

5 import GroupRepresentation from 'keycloak-admin/lib/defs/groupRepresentation';
                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

src/models/user.ts:3:32 - error TS2307: Cannot find module 'keycloak-admin/lib/defs/userRepresentation'.

3 import UserRepresentation from 'keycloak-admin/lib/defs/userRepresentation';
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This is also an issue when running jest on your host machine as well. The prepare script executes after install which creates the `lib/*` build files in this case. 
